### PR TITLE
Archive fix

### DIFF
--- a/SpecialContentStaging.php
+++ b/SpecialContentStaging.php
@@ -6,6 +6,7 @@ class SpecialContentStaging extends SpecialPage {
 	private $mwNamespace;
 	private $pagePrefix;
 	private $stages;
+	private $archiveMarker = "\n[[Category:ContentStagingArchive]]";
 
 	public function __construct() {
 		global $wgContentStagingPrefix, $wgContentStagingNamespace, $wgContentStagingStages;
@@ -284,7 +285,7 @@ class SpecialContentStaging extends SpecialPage {
 
 		$text = $oldContent->getNativeData();
 
-		$text .= "\n[[Category:ContentStagingArchive]]";
+		$text .= $this->archiveMarker;
 		$page->doEditContent( new WikitextContent( $text ), 'archived by ContentStaging' );
 
 		return true;
@@ -315,7 +316,7 @@ class SpecialContentStaging extends SpecialPage {
 
 		$text = $oldContent->getNativeData();
 
-		$text = str_replace( '[[Category:ContentStagingArchive]]', '', $text );
+		$text = str_replace( $this->archiveMarker, '', $text );
 		$page->doEditContent( new WikitextContent( $text ), 'restored by ContentStaging' );
 
 		return true;

--- a/SpecialContentStaging.php
+++ b/SpecialContentStaging.php
@@ -6,7 +6,7 @@ class SpecialContentStaging extends SpecialPage {
 	private $mwNamespace;
 	private $pagePrefix;
 	private $stages;
-	private $archiveMarker = "\n[[Category:ContentStagingArchive]]";
+	private $archiveMarker = "\n<noinclude>[[Category:ContentStagingArchive]]</noinclude>";
 
 	public function __construct() {
 		global $wgContentStagingPrefix, $wgContentStagingNamespace, $wgContentStagingStages;

--- a/SpecialContentStaging.php
+++ b/SpecialContentStaging.php
@@ -90,10 +90,10 @@ class SpecialContentStaging extends SpecialPage {
 						$element = array_search( $currStage, $keys );
 						if ( $stage !== "production" ) {
 							$targetStage = $keys[$element + 1];
+							$targetPage = $stages[$targetStage];
 						}
 
 						$currPage = $stages[$stage];
-						$targetPage = $stages[$targetStage];
 
 						$stagingStatus = '<span style="color: green">&#10003;</span>';
 						if ( $stage !== "production" && ( !$this->wikiPageExists( $targetPage ) || $this->stageContentDiffers( $currPage, $targetPage, $currStage, $targetStage ) ) ) {


### PR DESCRIPTION
Took me ages to find out, what actually happened. I stumbled across this when I tried to move a L10h16 back into the list of _used_ pages.

So basically, moving pages including Template:SpendenLayout into the archive results in all the pages transcluded by SpendenLayout to be archived as well. Although the categorization wikitext was removed, the page remained in the archive, when it transcluded other stuff from the archive.

The solution is simple.

But: I think we need to remove the archive flag from all pages, just to be sure.
